### PR TITLE
docs(nil): 修改nil类型map示例的歧义，修正示例代码缩进

### DIFF
--- a/src/essential/impl/err/3.nil.md
+++ b/src/essential/impl/err/3.nil.md
@@ -8,7 +8,7 @@
 type A struct {
   b B
   c C
-     d D
+  d D
 }
 
 func (a A) Close() error {
@@ -197,7 +197,7 @@ func main() {
 }
 ```
 
-当 map 为`nil`的时候，还可以对其进行访问
+当 map 为`nil`的时候，还可以对其进行访问，但`nil`的 map 是只读的，一旦尝试写入就会引发panic
 
 ```go
 func main() {
@@ -205,6 +205,10 @@ func main() {
   i, ok := s[""]
   fmt.Println(i, ok)
   fmt.Println(len(s))
+
+  // 尝试写入时，会引发panic
+  s["a"] = 1 // panic: assignment to entry in nil map
+
 }
 ```
 


### PR DESCRIPTION
感谢作者大大的文档，阅读的过程中发现这里不够细致，前面说切片可以访问并增加元素，但没有明说`nil` map的修改操作会带来的后果，可能带来歧义，修补了一下。

<img width="442" height="358" alt="9a2690df7f64519b068e7ade45da089c" src="https://github.com/user-attachments/assets/59d0cf30-a903-4130-9512-ceac7d652770" />
<img width="652" height="218" alt="7ef7174d92d316fd231567cec6f71915" src="https://github.com/user-attachments/assets/da698a2b-1472-4de3-bd3c-372a889159a6" />
