### PR TITLE
[Bug-语法进阶-并发-锁]：互斥锁一个示例中打印数据与解锁顺序问题

### DIFF
--- a/src/essential/senior/110.concurrency.md
+++ b/src/essential/senior/110.concurrency.md
@@ -1581,9 +1581,10 @@ func main() {
       ans := 1
       // 修改数据
       *data = temp + ans
+      // 打印当前协程修改后的值
+      fmt.Println(*data)
       // 解锁
       lock.Unlock()
-      fmt.Println(*data)
       wait.Done()
     }(&count)
   }


### PR DESCRIPTION
Issue：#72 
示例中的一个小问题，应先打印当前协程修改后的值，再解锁变量