### PR TITLE
docs: fix broken star history chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ pnpm docs:build
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=Open-Source-CQUT/Golang-Doc&type=Timeline)](https://star-history.com/#Open-Source-CQUT/Golang-Doc&Timeline)
+[![Star History Chart](https://star-history.dera.page/svg?repos=Open-Source-CQUT/Golang-Doc&type=Timeline)](https://star-history.dera.page/#Open-Source-CQUT/Golang-Doc&Timeline)
 
 ## 贡献
 


### PR DESCRIPTION
The Star History chart in the README no longer loads because of GitHub stargazer API restrictions. Update the chart to use star-history.dera.page, which uses a different data source that needs no API token, restoring the chart for the repository.